### PR TITLE
feat: Add author profile component below blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -22,7 +22,6 @@ export async function generateMetadata({ params }) {
   let {
     title,
     publishedAt: publishedTime,
-    publishedA1t?: publishedTime,
     summary: description,
     image,
   } = post.metadata

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation'
 import { CustomMDX } from 'app/components/mdx'
+import AuthorProfile from 'app/components/AuthorProfile'
 import { formatDate, getBlogPosts } from 'app/blog/utils'
 import { baseUrl } from 'app/sitemap'
 
@@ -95,6 +96,13 @@ export default async function Blog({ params }) {
       <article className="prose">
         <CustomMDX source={post.content} />
       </article>
+      <AuthorProfile
+        author={{
+          name: 'John Doe',
+          bio: 'A passionate writer and developer.',
+          avatarUrl: '/images/avatar.png',
+        }}
+      />
     </section>
   )
 }

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -22,6 +22,7 @@ export async function generateMetadata({ params }) {
   let {
     title,
     publishedAt: publishedTime,
+    publishedA1t?: publishedTime,
     summary: description,
     image,
   } = post.metadata

--- a/app/components/AuthorProfile.tsx
+++ b/app/components/AuthorProfile.tsx
@@ -1,0 +1,27 @@
+interface Author {
+  name: string
+  bio: string
+  avatarUrl: string
+}
+
+export default function AuthorProfile({ author }: { author: Author }) {
+  return (
+    <div className="mt-12 border-t border-neutral-200 pt-8 dark:border-neutral-700">
+      <div className="flex items-center gap-4">
+        <img
+          src={author.avatarUrl}
+          alt={author.name}
+          className="h-16 w-16 rounded-full object-cover"
+        />
+        <div>
+          <p className="font-bold text-neutral-900 dark:text-neutral-100">
+            {author.name}
+          </p>
+          <p className="text-sm text-neutral-600 dark:text-neutral-400">
+            {author.bio}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 📝 변경사항

게시글 하단에 작가 프로필(아바타, 이름, 소개글) 섹션을 추가한다.

### 주요 변경사항
- [x] UI/UX 개선
- 새로운 `AuthorProfile` 컴포넌트 생성
- 블로그 게시글 상세 페이지에 작가 프로필 렌더링

### 상세 설명
독자들에게 더 개인적인 느낌을 주기 위해 게시글 하단에 작가 프로필 섹션을 추가한다.
- Tailwind CSS로 스타일링 (둥근 아바타, 굵은 이름, 다크모드 지원)
- 현재는 임시 하드코딩 데이터를 사용

## 🔍 변경된 파일

- `app/components/AuthorProfile.tsx` - 새로운 작가 프로필 컴포넌트
- `app/blog/[slug]/page.tsx` - AuthorProfile 컴포넌트 적용

## 🧪 테스트

- [ ] 로컬에서 개발 서버 실행 확인
- [ ] 블로그 포스트 렌더링 확인
- [ ] 반응형 디자인 확인

### 테스트 방법
```bash
pnpm dev
```

## ✅ 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체적으로 코드를 검토했습니다

## 📚 관련 이슈

Closes #2